### PR TITLE
Create example_expected.json

### DIFF
--- a/tests/example_expected.json
+++ b/tests/example_expected.json
@@ -1,0 +1,64 @@
+{
+    "confidence": "High",
+    "reason": "本地文件结构清晰，Season 1 和 Season 2 分别对应 TMDB 的第一季和第二季，且集数匹配（各24集）。特典文件位于 Specials 目录，与 TMDB 第0季的 OVA 内容一致。文件命名规范，使用 S01E01 格式，与 TMDB 季集号完全对应。",
+    "season_mapping": [
+        {
+            "local_group_name": "Season 1",
+            "maps_to_tmdb_seasons": [1]
+        },
+        {
+            "local_group_name": "Season 2",
+            "maps_to_tmdb_seasons": [2]
+        },
+        {
+            "local_group_name": "Specials",
+            "maps_to_tmdb_seasons": [0]
+        }
+    ],
+    "file_mapping": [
+        {
+            "file_path": "Season 1/Jujutsu Kaisen S01E01.mkv",
+            "tmdb_season": 1,
+            "tmdb_episode": 1,
+            "episode_type": "regular",
+            "confidence": "High"
+        },
+        {
+            "file_path": "Season 1/Jujutsu Kaisen S01E02.mkv",
+            "tmdb_season": 1,
+            "tmdb_episode": 2,
+            "episode_type": "regular",
+            "confidence": "High"
+        },
+        {
+            "file_path": "Season 2/Jujutsu Kaisen S02E01.mkv",
+            "tmdb_season": 2,
+            "tmdb_episode": 1,
+            "episode_type": "regular",
+            "confidence": "High"
+        },
+        {
+            "file_path": "Season 2/Jujutsu Kaisen S02E02.mkv",
+            "tmdb_season": 2,
+            "tmdb_episode": 2,
+            "episode_type": "regular",
+            "confidence": "High"
+        },
+        {
+            "file_path": "Specials/Jujutsu Kaisen OVA01.mkv",
+            "tmdb_season": 0,
+            "tmdb_episode": 1,
+            "episode_type": "special",
+            "confidence": "High"
+        },
+        {
+            "file_path": "Specials/Jujutsu Kaisen OVA02.mkv",
+            "tmdb_season": 0,
+            "tmdb_episode": 2,
+            "episode_type": "special",
+            "confidence": "High"
+        }
+    ],
+    "extra_notes": "TMDB 第0季为特典（OVA），与本地 Specials 目录内容完全对应。本地未出现半集或总集编号情况，所有剧集均按标准季集划分，无异常命名。剧场版未包含在本数据中，不影响当前分析。"
+}
+


### PR DESCRIPTION
补充缺失的example_expected.json，以解决webui上AI测试报错的问题 #32，对应日志`{"event": "[AI识别测试] 期望结果文件不存在: /Bangumi_Auto_Rename/tests/example_expected.json", "timestamp": "2025-08-22 10:21:33", "level": "warning"}`

不过#32中OpenAI 番剧命名失败（日志报错普遍为JSON结构验证失败）的问题仍未解决。

<img width="553" height="442" alt="Image" src="https://github.com/user-attachments/assets/6cb511e6-2340-4ff9-905b-c03a0d371172" />
<img width="546" height="406" alt="Image" src="https://github.com/user-attachments/assets/ea52bfbc-8f2e-4019-b1b5-7d0c1738005a" />